### PR TITLE
Fix TypeError when sak_user_templates is missing (console.warning -> console.warn)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -609,7 +609,7 @@ class SwissArmyKnifeCard extends LitElement {
       throw Error(version, ' - card::get styles - System Templates reference NOT defined!');
     }
     if (!SwissArmyKnifeCard.lovelace.config.sak_user_templates) {
-      console.warning(version, ' - SAK - User Templates reference NOT defined. Did you NOT include them?');
+      console.warn(version, ' - SAK - User Templates reference NOT defined. Did you NOT include them?');
     }
 
     // #TESTING


### PR DESCRIPTION
Fixes https://github.com/AmoebeLabs/swiss-army-knife-card/issues/268

`console.warning` is not a function in the Console API; the correct method is `console.warn`. Because this line sits in the static `styles` getter, the TypeError aborts `customElements.define()` and the card never registers - the user only sees "Custom element doesn't exist: swiss-army-knife-card" when `sak_user_templates` is absent from the dashboard config, instead of the intended non-fatal warning.

One-line change in `src/main.js`; no behavior change beyond the warning actually being logged and registration proceeding.